### PR TITLE
seemingly required changes for tsc / package locking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ WORKDIR /app
 
 # Copy the build files from the builder stage
 COPY --from=builder /app/build ./build
-COPY package.json ./
+COPY package.json package-lock.json ./
 
 # Install only production dependencies
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 # Expose the port on which the server will run (if required)
 # EXPOSE 8080

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "build"
   ],
   "scripts": {
-    "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "build": "npx tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "prepare": "npm run build",
-    "watch": "tsc --watch",
+    "watch": "npx tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
Entirely possible I was missing something, however these changes did get me building a docker image.

* invoking `tsc` via `npx`
* clean install without invoking scripts
* ensure `package.lock` is present